### PR TITLE
Create XDCCadv.mrc

### DIFF
--- a/XDCCadv.mrc
+++ b/XDCCadv.mrc
@@ -1,0 +1,13 @@
+;
+; Script Name:     XDCCadv (v1.0)
+; Created by:      Rand (#NIBL @ Rizon)
+;
+
+on ^*:text:*:#nibl:{
+  if ($nick ishop $chan) {
+    haltdef
+    var %w = @XDCCadv
+    if (!$window(@XDCCadv)) { window -e %w }
+    aline %w $timestamp > $chan - $nick : $1-
+  }
+}


### PR DESCRIPTION
This is a simple v1 script to place all XDCC announced information from #NIBL specifically, into its very own query (PM) window to clean up the #NIBL chat and make it easier for you to navigate and catch the releases you want to see.

NOTE: Since this is just the simple version it will catch ALL %halfop lines, which is fine in #NIBL because only XDCC Bots are %halfop, remember that when using for other channels.

To load in your mirc file just place it in your scripts directory (Usually C:\Users\YourUser\AppData\mIRC\scripts) or wherever you installed it to, then load irc and type /load -rs scripts\XDCCadv.mrc
